### PR TITLE
generalise file validation for bam and cram

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Additional commandline options can be specified to:
 
 A full list of options can be displayed via `htsget-compliance --help`
 
+Requires [`Samtools` suite](http://www.htslib.org/) to be available in your path
+
 ## License
 
 See the [LICENSE](https://github.com/ga4gh/htsget-compliance/blob/master/LICENSE)

--- a/ga4gh/htsget/compliance/file_validator.py
+++ b/ga4gh/htsget/compliance/file_validator.py
@@ -26,9 +26,9 @@ class FileValidator(object):
         s = ""
         if fp.endswith(".sam"):
             s = self.load_sam(fp)
-        elif fp.endswith(".bam"):
-            s = self.load_bam(fp)
-        
+        elif fp.endswith(".bam") or fp.endswith(".cram"):
+            s = self.load_binary(fp)
+
         return s
 
     def load_sam(self, fp):
@@ -46,7 +46,7 @@ class FileValidator(object):
                     s.append("\t".join(ls[:11]))
         return "\n".join(s) + "\n"
 
-    def load_bam(self, fp):
+    def load_binary(self, fp):
         s = []
         for line in os.popen("samtools view " + fp).readlines():
             ls = line.rstrip().split("\t")


### PR DESCRIPTION
If we are restricting to comparing text data up to the read sequence column I guess it will be the same for bam and cram.