### PR TITLE
Fix: test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,21 @@ apt-get install samtools uv  (OSX: brew install samtools uv)
 uv venv .
 pip install crypt4gh
 ```
-To install `htsget-compliance`, clone the Github repository, then install via setuptools:
+To install `htsget-compliance`, clone the Github repository, then install via setuptools in a new virtual environment.
 
-```
-source .venv/bin/activate
+Create a new virtual environment:
+
+```sh
 git clone https://github.com/ga4gh/htsget-compliance.git
 cd htsget-compliance
-python setup.py install
+
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+Install the package:
+```sh
+pip install -e .
 ```
 
 ## Quickstart
@@ -37,7 +45,7 @@ python setup.py install
 Running the following:
 
 ```shell
-% htsget-compliance https://htsget.ga4gh-demo.org  | jq '.["summary"]'
+htsget-compliance https://htsget.ga4gh-demo.org  | jq '.["summary"]'
 ```
 
 Should ideally yield:

--- a/ga4gh/htsget/compliance/config/constants.py
+++ b/ga4gh/htsget/compliance/config/constants.py
@@ -13,7 +13,7 @@ Attributes:
     DEFAULT_VARIANTS_URLPATH (str): unformated url template for variants-related
         requests
     READS_ID_FOUND_1 (str): id for test case(s)
-    READS_ID_FOUND_2 (str): id for test case(s)
+    READS_ID_FILE_BAM (str): id for test case(s)
     READS_ID_NOTFOUND_1 (str): id for test case(s)
     READS_ID_NOTFOUND_2 (str): id for test case(s)
 """
@@ -40,12 +40,14 @@ ID_URLPATH = "/{obj_id}"
 
 # OBJECT IDs FOR TEST CASES
 READS_ID_FOUND_1 = "htsnexus_test_NA12878"
-READS_ID_FOUND_2 = "htsnexus_test_NA12878.bam"
+READS_ID_FILE_BAM = "htsnexus_test_NA12878.bam"
+READS_ID_FILE_CRAM = "htsnexus_test_NA12878.cram"
 READS_ID_NOTFOUND_1 = "notfound123456789"
 READS_ID_NOTFOUND_2 = "notfound987654321"
 
 VARIANTS_ID_FOUND_1 = "spec-v4.3"
-VARIANTS_ID_FOUND_2 = "spec-v4.3.vcf.gz"
+VARIANTS_ID_FILE_VCF = "spec-v4.3.vcf.gz"
+VARIANTS_ID_FILE_BCF = "spec-v4.3.bcf"
 VARIANTS_ID_NOTFOUND_1 = "notfoundmeowmeow"
 VARIANTS_ID_NOTFOUND_1 = "notfoundfoobarbaz"
 

--- a/ga4gh/htsget/compliance/config/methods.py
+++ b/ga4gh/htsget/compliance/config/methods.py
@@ -35,9 +35,8 @@ def fetch_inline_data(url: str) -> (bytes, object):
     return (data, phony_response)
 
 
-def fetch_remote_url(url: str or dict, params=None) -> (bytes, object):
+def fetch_remote_url(url: str or dict, params=None, headers=None) -> (bytes, object):
     data = b""
-    headers = {}
 
     if isinstance(url, dict):
         headers = url.get("headers", {})
@@ -52,7 +51,7 @@ def fetch_remote_url(url: str or dict, params=None) -> (bytes, object):
     return (data, response)
 
 
-def fetch_url(url: str or dict, params={}) -> (bytes, list):
+def fetch_url(url: str or dict, params={}, headers=None) -> (bytes, list):
     ''' Fetches and concatenates the payload htsget "urls" array with
         multiple urls where some of those urls contain base64-encoded
         data.
@@ -72,14 +71,14 @@ def fetch_url(url: str or dict, params={}) -> (bytes, list):
     # Determine whether we have been given a "top-level htsget url" or something else
     if isinstance(url, str):
         # Data is the actual url so that next conditional can work on it as a dict
-        url, response = fetch_remote_url(url)
+        url, response = fetch_remote_url(url, params, headers)
         responses.append(response)
     if isinstance(url, dict):
         urls = url.get("htsget", {}).get("urls", [])
         for entry in urls:
             url = entry.get("url")
             if url.startswith(("http://", "https://")):
-                one_data, one_response = fetch_remote_url(url, params=params)
+                one_data, one_response = fetch_remote_url(url, params=params, headers=headers)
             elif url.startswith("data:;base64,"):
                 one_data, one_response = fetch_inline_data(url)
 

--- a/ga4gh/htsget/compliance/config/test_case_property_matrix.py
+++ b/ga4gh/htsget/compliance/config/test_case_property_matrix.py
@@ -29,6 +29,9 @@ def construct_reads_test_cases_matrix():
             filename += "." + reads_reference
         filepath = os.path.join(c.DATA_DIR, "reads", filename)
         return filepath
+
+    def construct_expected_key_path():
+        return os.path.join(c.DATA_DIR, "c4gh", "keys", c.PRIVATE_KEY_CRYPT4GH)
     
     def construct_name(reads_id, reads_format, reads_reference):
         name = "reads: " + reads_id
@@ -38,14 +41,10 @@ def construct_reads_test_cases_matrix():
             name += " - " + reads_reference
         return name
 
-    reads_ids = [
-        c.READS_ID_FOUND_1
-    ]
-
-    reads_formats = [
-        None,
-        c.FORMAT_BAM,
-        c.FORMAT_CRAM,
+    reads = [
+        (None, c.READS_ID_FOUND_1, c.READS_ID_FILE_BAM),
+        (c.FORMAT_BAM, c.READS_ID_FOUND_1, c.READS_ID_FILE_BAM),
+        (c.FORMAT_CRAM, c.READS_ID_FOUND_1, c.READS_ID_FILE_CRAM)
     ]
 
     # reads_references = [
@@ -57,29 +56,28 @@ def construct_reads_test_cases_matrix():
 
     reads_cases = []
 
-    for reads_id in reads_ids:
-        for reads_format in reads_formats:
-            #for reads_reference in reads_references:
-                for encryption_scheme in encryption_schemes:
-                    params = {}
-                    add_format_param(params, reads_format)
-                    #add_reference_name_param(params, '') #reads_reference)
-                    if encryption_scheme is not None:
-                        add_encryption_scheme_param(params, encryption_scheme)
+    for (reads_format, reads_id, reads_file) in reads:
+        for encryption_scheme in encryption_schemes:
+            params = {}
+            add_format_param(params, reads_format)
+            #add_reference_name_param(params, '') #reads_reference)
+            if encryption_scheme is not None:
+                add_encryption_scheme_param(params, encryption_scheme)
 
-                    props = {
-                        "name": construct_name(
-                            reads_id, reads_format, ''#, reads_reference
-                        ),
-                        "url_function": methods.FORMAT_READS_URL,
-                        "url_params": params,
-                        "obj_id": reads_id,
-                        "expected_response_status": c.STATUS_OK,
-                        "expected_contents": construct_expected_contents_path(
-                            reads_id, '')#, reads_reference)
-                    }
+            props = {
+                "name": construct_name(
+                    reads_id, reads_format, ''#, reads_reference
+                ),
+                "url_function": methods.FORMAT_READS_URL,
+                "url_params": params,
+                "obj_id": reads_id,
+                "expected_response_status": c.STATUS_OK,
+                "expected_contents": construct_expected_contents_path(
+                    reads_file, ''),#, reads_reference)
+                "expected_key": construct_expected_key_path(),
+            }
 
-                    reads_cases.append(props)
+            reads_cases.append(props)
     
     return reads_cases
 
@@ -103,7 +101,10 @@ def construct_variants_test_cases_matrix():
             filename += "." + variants_reference
         filepath = os.path.join(c.DATA_DIR, "variants", filename)
         return filepath
-    
+
+    def construct_expected_key_path():
+        return os.path.join(c.DATA_DIR, "c4gh", "keys", c.PRIVATE_KEY_CRYPT4GH)
+
     def construct_name(variants_id, variants_format, variants_reference):
         name = "variants: " + variants_id
         if variants_format:
@@ -112,14 +113,10 @@ def construct_variants_test_cases_matrix():
             name += " - " + variants_reference
         return name
 
-    variants_ids = [
-        c.VARIANTS_ID_FOUND_1
-    ]
-
-    variants_formats = [
-        None,
-        c.FORMAT_VCF,
-        c.FORMAT_BCF
+    variants = [
+        (None, c.VARIANTS_ID_FOUND_1, c.VARIANTS_ID_FILE_VCF),
+        (c.FORMAT_VCF, c.VARIANTS_ID_FOUND_1, c.VARIANTS_ID_FILE_VCF),
+        (c.FORMAT_BCF, c.VARIANTS_ID_FOUND_1, c.VARIANTS_ID_FILE_BCF)
     ]
 
     # variants_references = [
@@ -129,28 +126,27 @@ def construct_variants_test_cases_matrix():
 
     variants_cases = []
 
-    for variants_id in variants_ids:
-        for variants_format in variants_formats:
-            #for variants_reference in variants_references:
-                for encryption_scheme in encryption_schemes:
-                    params = {}
-                    add_format_param(params, variants_format)
-                    #add_reference_name_param(params, '') #variants_reference)
-                    if encryption_scheme is not None:
-                        add_encryption_scheme_param(params, encryption_scheme)
+    for (variants_format, variants_id, variants_file) in variants:
+        for encryption_scheme in encryption_schemes:
+            params = {}
+            add_format_param(params, variants_format)
+            #add_reference_name_param(params, '') #variants_reference)
+            if encryption_scheme is not None:
+                add_encryption_scheme_param(params, encryption_scheme)
 
-                    props = {
-                        "name": construct_name(
-                            variants_id, variants_format, ''#, variants_reference
-                        ),
-                        "url_function": methods.FORMAT_VARIANTS_URL,
-                        "url_params": params,
-                        "obj_id": variants_id,
-                        "expected_response_status": c.STATUS_OK,
-                        "expected_contents": construct_expected_contents_path(
-                            variants_id, '')#, variants_reference)
-                    }
+            props = {
+                "name": construct_name(
+                    variants_id, variants_format, ''#, variants_reference
+                ),
+                "url_function": methods.FORMAT_VARIANTS_URL,
+                "url_params": params,
+                "obj_id": variants_id,
+                "expected_response_status": c.STATUS_OK,
+                "expected_contents": construct_expected_contents_path(
+                    variants_file, ''),#, variants_reference)
+                "expected_key": construct_expected_key_path(),
+            }
 
-                    variants_cases.append(props)
+            variants_cases.append(props)
     
     return variants_cases

--- a/ga4gh/htsget/compliance/test_case.py
+++ b/ga4gh/htsget/compliance/test_case.py
@@ -19,6 +19,7 @@ class TestCase(object):
         self.set_obj_id(props["obj_id"])
         self.set_expected_response_status(props["expected_response_status"])
         self.set_expected_contents(props["expected_contents"])
+        self.expected_key = props["expected_key"]
         self.set_kwargs(kwargs)
 
     def validate_response_code(self, responses: list):
@@ -39,7 +40,7 @@ class TestCase(object):
         aggregator.aggregate(params)
         returned_filepath = aggregator.get_output_filepath()
         expected_filepath = self.get_expected_contents()
-        file_validator = FileValidator(returned_filepath, expected_filepath)
+        file_validator = FileValidator(returned_filepath, expected_filepath, self.expected_key)
         validation_result = file_validator.validate()
         if validation_result == FileValidator.FAILURE:
             raise Exception("returned file does not match expected")


### PR DESCRIPTION
### Changes
* Various small fixes:
    * Passing headers to fetch url.
    * Commands using `subprocess` instead of `os`.
    * Passing full key path to crypt4gh decrypt.
    * Reading using samtools/bcftools after decrypting to get result output.
    * Fix extension issues in tests and htsfile.
    * Make exception to BCF viewCommand in expected output as it encodes the file path which is allowed to be different.
* Update docs with virtual env advice and using `pip install -e .`

This change now results in all the tests passing.